### PR TITLE
Document the standard for the phone number

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-# Signal
+# Signal, E.164 format, i.e. +491512345678
 SIGNAL_PHONE_NUMBER=
 
 # ChatGPT


### PR DESCRIPTION
Initially I tried it using `0049` which wasn't compliant with [E.164](https://en.wikipedia.org/wiki/E.164).
This PR adds the format as a comment to prevent user confusions.